### PR TITLE
Update windows_icon.py

### DIFF
--- a/f_icon/windows_icon.py
+++ b/f_icon/windows_icon.py
@@ -131,7 +131,7 @@ class IconCreator:
             icon_name = self._append_date(icon_name)
 
         img = Image.open(temp_file)
-        img = img.resize((256, 256), Image.ANTIALIAS)
+        img = img.resize((256, 256), Image.LANCZOS)
         img.save(placement_path + os.sep + icon_name, sizes=[(256, 256)])
 
         self._generate_desktop_ini(folder, os.path.join(placement, icon_name))


### PR DESCRIPTION
`ANTIALIAS` was removed in Pillow 10.0.0 (after being deprecated through many previous versions). Now you need to use `LANCZOS`.